### PR TITLE
Use explicit count modifiers

### DIFF
--- a/Syntaxes/Julia.tmLanguage
+++ b/Syntaxes/Julia.tmLanguage
@@ -552,7 +552,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8}|.)</string>
+					<string>\\(\\|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8}|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.julia</string>
 				</dict>


### PR DESCRIPTION
The `{,N}` extension is not supported by most Regexp engines, as it is
an Onigurma-only extension.

Github uses PCRE for parsing and this shorthand isn't supported.