### PR TITLE
Added evaluate command

### DIFF
--- a/Commands/Evaluate.tmCommand
+++ b/Commands/Evaluate.tmCommand
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+if [ -z "${TM_SELECTED_TEXT}" ]; then
+    # echo TM_SELECTED_TEXT not defined
+    CONTENTS=${TM_CURRENT_LINE}
+else
+    # echo TM_SELECTED_TEXT defined
+    CONTENTS=${TM_SELECTED_TEXT}
+fi
+
+osascript "$TM_BUNDLE_SUPPORT/paste_script_in_target_terminal_process.applescript" "$CONTENTS" "julia"</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>@e</string>
+	<key>name</key>
+	<string>Evaluate Julia</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>discard</string>
+	<key>scope</key>
+	<string>source.julia</string>
+	<key>semanticClass</key>
+	<string>process.external.run.julia</string>
+	<key>uuid</key>
+	<string>150934C9-9F98-472A-95CB-74D92836ABD8</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Commands/Run Julia (Terminal).tmCommand
+++ b/Commands/Run Julia (Terminal).tmCommand
@@ -6,27 +6,10 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-[[ -z "$TM_FILEPATH" ]] &amp;&amp; TM_TMPFILE=$(mktemp -t pythonInTerm)
-: "${TM_FILEPATH:=$TM_TMPFILE}"; cat &gt;"$TM_FILEPATH"
 
-esc () {
-STR="$1" ruby18 &lt;&lt;"RUBY"
-   str = ENV['STR']
-   str = str.gsub(/'/, "'\\\\''")
-   str = str.gsub(/[\\"]/, '\\\\\\0')
-   print "'#{str}'"
-RUBY
-}
+CONTENTS="reload(\"${TM_FILEPATH}\")"
 
-osascript &lt;&lt;- APPLESCRIPT
-	tell app "Terminal"
-	    launch
-	    activate
-	    do script "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TM_JULIA:-julia}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
-	    set position of first window to { 100, 100 }
-	end tell
-APPLESCRIPT
-</string>
+osascript "$TM_BUNDLE_SUPPORT/paste_script_in_target_terminal_process.applescript" "$CONTENTS" "julia"</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Support/paste_script_in_target_terminal_process.applescript
+++ b/Support/paste_script_in_target_terminal_process.applescript
@@ -1,0 +1,23 @@
+on run argv
+	
+	set scriptToPaste to item 1 of argv
+	set targetProcess to item 2 of argv
+	
+	tell application "Terminal"
+		set windowCount to number of windows
+		repeat with windowIndex from 1 to windowCount
+			set tabCount to number of tabs of window windowIndex
+			repeat with tabIndex from 1 to tabCount
+				if processes of tab tabIndex of window windowIndex contains targetProcess then
+					
+					do script scriptToPaste in tab tabIndex of window windowIndex
+                    set frontmost of window windowIndex to true
+                    set selected of tab tabIndex of window windowIndex to true                    
+                    -- tell application "System Events" to set frontmost of process "Terminal" to true -- Not necessesarily wanted behavior
+					exit repeat
+					
+				end if
+			end repeat
+		end repeat
+	end tell
+end run

--- a/info.plist
+++ b/info.plist
@@ -14,6 +14,7 @@
 		<array>
 			<string>E8BC7C6A-067B-4D5C-927A-E4EBF70614F5</string>
 			<string>38C8DF23-43F7-4F9C-A183-37EAD5ED3ADA</string>
+            <string>150934C9-9F98-472A-95CB-74D92836ABD8</string>
 		</array>
 	</dict>
 	<key>name</key>


### PR DESCRIPTION
Hitting ⌘-E will take the selected text and evaluate it in the the the first terminal tab/window it finds that is running Julia. If there is no selected text, it will use the current line.