### PR TITLE
Improved folding and indentation support

### DIFF
--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -8,10 +8,6 @@
 	<string>source.julia</string>
 	<key>settings</key>
 	<dict>
-		<key>decreaseIndentPattern</key>
-		<string>^\s*((end|else|elseif|catch|finally)\b)</string>
-		<key>increaseIndentPattern</key>
-		<string>(^\s*(if|while|for|function|macro|immutable|type|let|else|elseif|quote|try|catch|finally)\b.*\s*$)|(^.*\b(do|begin)\b\s*$)</string>
 		<key>shellVariables</key>
 		<array>
 			<dict>

--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Folding</string>
+	<key>scope</key>
+	<string>source.julia -string</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*(end|else|elseif|catch|finally)\b.*$</string>
+		<key>foldingStartMarker</key>
+		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|module|.*\)\s*do)\b(?!.*\bend\b[^\]]*$).*$</string>
+		<key>foldingStopMarker</key>
+		<string>^\s*end\b.*$</string>
+		<key>increaseIndentPattern</key>
+		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!.*\bend\b[^\]]*$).*$</string>
+	</dict>
+	<key>uuid</key>
+	<string>B9FA1624-24DD-44AD-BB52-CEBECE1E8DAC</string>
+</dict>
+</plist>

--- a/Syntaxes/Julia.tmLanguage
+++ b/Syntaxes/Julia.tmLanguage
@@ -14,10 +14,6 @@
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!.*\bjulia\s*$</string>
-	<key>foldingStartMarker</key>
-	<string>^\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|let)\b(?!.*\bend\b).*$</string>
-	<key>foldingStopMarker</key>
-	<string>^\s*(?:end)\b.*$</string>
 	<key>keyEquivalent</key>
 	<string>^~J</string>
 	<key>name</key>
@@ -228,7 +224,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(function|macro)\s+([a-zA-Z0-9_\.]+!?)\b</string>
+					<string>\b(function|stagedfunction|macro)\s+([a-zA-Z0-9_\.]+!?)\b</string>
 				</dict>
 			</array>
 		</dict>
@@ -238,7 +234,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(?:function|type|immutable|macro|quote|abstract|bitstype|typealias|module|baremodule|new)\b</string>
+					<string>\b(?:function|stagedfunction|type|immutable|macro|quote|abstract|bitstype|typealias|module|baremodule|new)\b</string>
 					<key>name</key>
 					<string>keyword.other.julia</string>
 				</dict>


### PR DESCRIPTION
This patch does several things:

* Move the folding patterns out of Julia.tmLanguage and into their own file: "Folding.tmPreferences".  This seems to be the more idiomatic way to write bundles for TextMate 2, and it makes editing easier as the folding patterns are now visible in the Bundle editor.
* Move the indentation patterns out of the Comments preferences into Folding preferences alongside the indentation patterns.  These two settings should be highly coupled, so it makes sense to have them right next to each other.
* Add folding, indentation, and keyword support for `stagedfunction`.
* Add folding support for `do` blocks
* Add folding and indentation support for macro-annotated blocks (e.g., `@inbounds for ...`).
* Fix indentation when `end` appears on the same line as the block head (but only when there's not a close bracket `]` that is between `end` and the newline. This allows for trailing comments, but prevents it from getting screwed up with an indexing expression `if x[end]`.)