### PR TITLE
Better support for type highlighting

### DIFF
--- a/Syntaxes/Julia.tmLanguage
+++ b/Syntaxes/Julia.tmLanguage
@@ -205,9 +205,14 @@
 							<key>name</key>
 							<string>entity.name.function.julia</string>
 						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.julia</string>
+						</dict>
 					</dict>
 					<key>match</key>
-					<string>^\s*([a-zA-Z0-9\._]+!?)(?=.*\)\s*=(?!=))</string>
+					<string>([\w.!]+)({[^}]*})?\((?=.*\)\s*=(?!=))</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -222,9 +227,14 @@
 							<key>name</key>
 							<string>entity.name.function.julia</string>
 						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.julia</string>
+						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(function|stagedfunction|macro)\s+([a-zA-Z0-9_\.]+!?)\b</string>
+					<string>\b(function|stagedfunction|macro)\s+([\w.!]+)({[^}]*})?\(</string>
 				</dict>
 			</array>
 		</dict>
@@ -285,6 +295,12 @@
 					<string>(?:=|:=|\+=|-=|\*=|/=|//=|\.//=|\.\*=|\\=|\.\\=|^=|\.^=|%=|\|=|&amp;=|\$=|&lt;&lt;=|&gt;&gt;=)</string>
 					<key>name</key>
 					<string>keyword.operator.update.julia</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?:::(?:(?:Union)?\([^)]*\)|\w+(?:{[^}]*})?))(?:\.\.\.)?</string>
+					<key>name</key>
+					<string>support.type.julia</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -595,25 +611,9 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(type|immutable)\s+([a-zA-Z0-9_]+)(\s*(&lt;:)\s*[.a-zA-Z0-9_:]+)?</string>
+					<string>(type|immutable)\s+(\w+)(\s*(&lt;:)\s*\w+(?:{.*})?)?</string>
 					<key>name</key>
 					<string>meta.type.julia</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.type.julia</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Matches a typed variable, such as 'id::String'</string>
-					<key>match</key>
-					<string>([a-zA-Z0-9_]+)(::[a-zA-Z0-9_{}]+)</string>
-					<key>name</key>
-					<string>meta.other.typed-variable.julia</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Much more consistent highlighting of ::T in all contexts.

I'm still not convinced about the highlighting of types, but the inconsistencies were driving me batty so I've gradually been working on making it more robust.  Here's a before/after comparison:

![screen shot 2015-04-01 at 9 32 22 pm](https://cloud.githubusercontent.com/assets/154641/6956103/eb076f50-d8b6-11e4-8c02-01e0b925d85b.png)

![screen shot 2015-04-01 at 9 31 25 pm](https://cloud.githubusercontent.com/assets/154641/6956104/edcf496a-d8b6-11e4-90d1-c0b5d07e08a4.png)
