### PR TITLE
Updates for Julia 0.6

### DIFF
--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -11,11 +11,11 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*(end|else|elseif|catch|finally)\b.*$</string>
 		<key>foldingStartMarker</key>
-		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|module|.*\)\s*do)\b(?!.*\bend\b[^\]]*$).*$</string>
+		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|macro|((abstract|primitive)\s+)?type|(mutable\s+)?struct|immutable|let|quote|try|begin|module|.*\)\s*do)\b(?!.*\bend\b[^\]]*$).*$</string>
 		<key>foldingStopMarker</key>
 		<string>^\s*end\b.*$</string>
 		<key>increaseIndentPattern</key>
-		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!.*\bend\b[^\]]*$).*$</string>
+		<string>^(\s*|.*=\s*|.*@\w*\s*)(if|while|for|function|macro|((abstract|primitive)\s+)?type|(mutable\s+)?struct|immutable|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!.*\bend\b[^\]]*$).*$</string>
 	</dict>
 	<key>uuid</key>
 	<string>B9FA1624-24DD-44AD-BB52-CEBECE1E8DAC</string>

--- a/Syntaxes/Julia.tmLanguage
+++ b/Syntaxes/Julia.tmLanguage
@@ -234,7 +234,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(function|stagedfunction|macro)\s+([\w.!]+)({[^}]*})?\(</string>
+					<string>\b(function|macro)\s+([\w.!]+)({[^}]*})?\(</string>
 				</dict>
 			</array>
 		</dict>
@@ -244,13 +244,13 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(?:function|stagedfunction|type|immutable|macro|quote|abstract|bitstype|typealias|module|baremodule|new)\b</string>
+					<string>\b(?:function|(mutable\s+)?struct|macro|quote|((primitive|abstract)\s+)?type|immutable|module|baremodule|new|where)\b</string>
 					<key>name</key>
 					<string>keyword.other.julia</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?:if|else|elseif|while|for|in|begin|let|end|do|try|catch|finally|return|break|continue)\b</string>
+					<string>\b(?:if|else|elseif|while|for|in|isa|begin|let|end|do|try|catch|finally|return|break|continue)\b</string>
 					<key>name</key>
 					<string>keyword.control.julia</string>
 				</dict>
@@ -611,7 +611,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(type|immutable)\s+(\w+)(\s*(&lt;:)\s*\w+(?:{.*})?)?</string>
+					<string>(((primitive|abstract)\s+)?type|(mutable\s+)?struct|immutable)\s+(\w+)(\s*(&lt;:)\s*\w+(?:{.*})?)?</string>
 					<key>name</key>
 					<string>meta.type.julia</string>
 				</dict>


### PR DESCRIPTION
This change accommodates the syntax changes for Julia 0.6. In particular, it adds:
* `where`
* infix `isa`
* `struct`/`mutable struct` (replaces `immutable` and `type`)
* `abstract type`/`primitive type` (replaces `abstract` and `bitstype`)

and it removes `stagedfunction`.

I don't really use TextMate but I installed it to try test these changes and it seems to work. But if anyone with more experience could provide any insight, that would be greatly appreciated.

---

Side note: Why is Travis enabled for this repo?