### PR TITLE
Add missing scopes

### DIFF
--- a/Snippets/Docstring.tmSnippet
+++ b/Snippets/Docstring.tmSnippet
@@ -9,6 +9,8 @@ $3
 """ -&gt;</string>
 	<key>name</key>
 	<string>Docstring</string>
+	<key>scope</key>
+	<string>source.julia</string>
 	<key>tabTrigger</key>
 	<string>doc</string>
 	<key>uuid</key>

--- a/Snippets/type.tmSnippet
+++ b/Snippets/type.tmSnippet
@@ -8,6 +8,8 @@
 end</string>
 	<key>name</key>
 	<string>type</string>
+	<key>scope</key>
+	<string>source.julia</string>
 	<key>tabTrigger</key>
 	<string>t</string>
 	<key>uuid</key>


### PR DESCRIPTION
Some snippets were missing scope declarations, making them available in *all* documents, not just Julia source code.